### PR TITLE
Fix scale control default parameters

### DIFF
--- a/src/ui/control/scale_control.ts
+++ b/src/ui/control/scale_control.ts
@@ -1,5 +1,4 @@
 import {DOM} from '../../util/dom';
-import {extend} from '../../util/util';
 
 import type {Map} from '../map';
 import type {ControlPosition, IControl} from './control';
@@ -51,8 +50,8 @@ export class ScaleControl implements IControl {
     _container: HTMLElement;
     options: ScaleControlOptions;
 
-    constructor(options: ScaleControlOptions) {
-        this.options = extend({}, defaultOptions, options);
+    constructor(options?: ScaleControlOptions) {
+        this.options = {...defaultOptions, ...options};
     }
 
     getDefaultPosition(): ControlPosition {


### PR DESCRIPTION
Before this CL, the following would generate an error:

```ts
const scaleCtrl = new ScaleControl():
```

because options is not marked as optional.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
 - [x] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Document any changes to public APIs.
 - [ ] Post benchmark scores.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
